### PR TITLE
Fix Snyk dependency results

### DIFF
--- a/catalyst/utils/paths.py
+++ b/catalyst/utils/paths.py
@@ -1,7 +1,7 @@
 """
 Canonical path locations for catalyst data.
 
-Paths are rooted at $ZIPLINE_ROOT if that environment variable is set.
+Paths are rooted at $CATALYST_ROOT if that environment variable is set.
 Otherwise default to expanduser(~/.catalyst)
 """
 from errno import EEXIST
@@ -124,7 +124,7 @@ def catalyst_root(environ=None):
     if environ is None:
         environ = os.environ
 
-    root = environ.get('ZIPLINE_ROOT', None)
+    root = environ.get('CATALYST_ROOT', None)
     if root is None:
         root = os.path.join(expanduser('~'), '.catalyst')
 

--- a/docs/source/releases.rst
+++ b/docs/source/releases.rst
@@ -1,6 +1,17 @@
 =============
 Release Notes
 =============
+Version 0.5.21
+^^^^^^^^^^^^^^
+**Release Date**: 2018-11-11
+
+Build
+~~~~~
+- Upgraded the `redo` lib version :issue:`494`
+- Added the ability to disable the alpha warning :issue:`493`
+- Memoized the call to the `get_exchnage_folder()` function :issue:`500`
+- Upgraded the `requests` lib
+
 Version 0.5.20
 ^^^^^^^^^^^^^^
 **Release Date**: 2018-09-13

--- a/etc/python2.7-environment.yml
+++ b/etc/python2.7-environment.yml
@@ -50,7 +50,7 @@ dependencies:
   - python-editor==1.0.3
   - pytz==2017.2
   - redo==2.0.1
-  - requests==2.18.4
+  - requests==2.20.1
   - requests-file==1.4.2
   - requests-ftp==0.3.1
   - six==1.11.0

--- a/etc/python3.6-environment-windows.yml
+++ b/etc/python3.6-environment-windows.yml
@@ -70,7 +70,7 @@ dependencies:
   - pysha3==1.0.2
   - python-editor==1.0.3
   - redo==2.0.1
-  - requests==2.18.4
+  - requests==2.20.1
   - requests-file==1.4.3
   - requests-ftp==0.3.1
   - requests-toolbelt==0.8.0

--- a/etc/python3.6-environment.yml
+++ b/etc/python3.6-environment.yml
@@ -73,7 +73,7 @@ dependencies:
   - pysha3==1.0.2
   - python-editor==1.0.3
   - redo==2.0.1
-  - requests==2.18.4
+  - requests==2.20.1
   - requests-file==1.4.3
   - requests-ftp==0.3.1
   - requests-toolbelt==0.8.0

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -29,7 +29,7 @@ python-dateutil==2.7.3
 six==1.11.0
 
 # For fetching remote data
-requests==2.18.4
+requests==2.20.1
 
 Cython==0.27.3
 


### PR DESCRIPTION
Some of these will already have been fixed and merged prior to `snyk` running it's automated tests, however they all need to be checked regardless. (Plus, the dependency bumps have been made on `develop` whilst `snyk` will have scanned `master`; but this PR should be scanned itself.) Fortunately most of these can be found in

If these libraries follow semantic versioning then expect lots of breaking api changes and probably a cascade of errors... Hopefully those test cases are good.

## `numpy`

**Arbitrary Code Execution:** Update to `1.16.3`

See: `etc/requirements.txt`

## `SQLAlchemy`

**SQL Injection:** Update to `1.2.18`

See: `etc/requirements.txt`

## `psutil`

**Double Free:** Update to `5.6.7`

See: `etc/requirements_blaze.txt`

## `pygments`

**Arbitrary Code Execution:** Update to `?`

See: `etc/requirements_dev.txt`

## `tornado`

**Denial of Service:** Update to `5.1.0`

See: `etc/requirements_dev.txt`

## `mistune`

**Cross Site Scripting:** Multiple, the next safest version is `0.8.1`

See: `etc/requirements_dev.txt`

### Side Note

The current target is `master` but will be changed to `develop`; it's only set to `master` so I can create the pull request *without changes*. It should really be an issue, but I haven't enabled issues apparently...

The bonus is, this will also trigger a `snyk` scan with the latest version of `develop` (where I branched off from).